### PR TITLE
Add Linguist rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-generated


### PR DESCRIPTION
This PR adds rules to `.gitattributes` to mark all `.html` files as "generated" for GitHub Linguist so the repo languages statistics is correct (currently, HTML ranks at the top by number of lines).

That being said, you should consider removing the rendered HTML file of the vignette from the repo, and rename the vignette to `wpgsd.Rmd` if it's the only vignette in the package.